### PR TITLE
Deprecating API authentication through query parameters

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ then
 elif [ -f ./sample_push_event.json ];
 then
     EVENT_PATH='./sample_push_event.json'
-    LOCAL_TEST=true
+    LOCAL_TEST=1
 else
     echo "No JSON data to process! :("
     exit 1
@@ -22,19 +22,21 @@ then
     # do something
     VERSION=$(date +%F.%s)
 
-    DATA="$(printf '{"tag_name":"v%s",' $VERSION)"
+    DATA="$(printf '{"tag_name":"v%s",' "$VERSION")"
     DATA="${DATA} $(printf '"target_commitish":"master",')"
-    DATA="${DATA} $(printf '"name":"v%s",' $VERSION)"
+    DATA="${DATA} $(printf '"name":"v%s",' "$VERSION")"
     DATA="${DATA} $(printf '"body":"Automated release based on keyword: %s",' "$*")"
     DATA="${DATA} $(printf '"draft":false, "prerelease":false}')"
 
-    URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?access_token=${GITHUB_TOKEN}"
+    # https://developer.github.com/changes/2020-02-10-deprecating-auth-through-query-param/
+    # URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases?access_token=${GITHUB_TOKEN}"
+    URL="https://api.github.com/repos/${GITHUB_REPOSITORY}/releases"
 
-    if [[ "${LOCAL_TEST}" == *"true"* ]];
-    then
+    if ((LOCAL_TEST)); then
         echo "## [TESTING] Keyword was found but no release was created."
     else
-        echo $DATA | http POST $URL | jq .
+        # https://httpie.io/docs/cli/http-headers
+        echo "$DATA" | http POST "$URL" "Authorization: token $GITHUB_TOKEN" | jq .
     fi
 # otherwise
 else


### PR DESCRIPTION
This fixes the issue reported at https://github.com/automate6500/keyword-release-action/issues/1

Sample run:

  https://github.com/hansonchar/test-keyword-release-action/actions/runs/3258433508/jobs/5350512415